### PR TITLE
Perf: Prefer literal pojo

### DIFF
--- a/src/resulta.ts
+++ b/src/resulta.ts
@@ -101,7 +101,7 @@ export function err<E extends Error>(e: E): Err<E> {
  * Construct an Ok with a value
  *
  */
-export function ok<A>(t: A) {
+export function ok<A>(t: A): Ok<A> {
 	return {
 		value: t,
 		status: ResultStatus.ok,
@@ -115,6 +115,7 @@ export function ok<A>(t: A) {
  *
  * If the `thunk` throws when awaited, an `Err` is returned with the caught
  * error, otherwise the returned value is `Ok`
+ *
  */
 export async function ofPromise<A, E extends Error>(
 	thunk: () => Promise<A>,
@@ -133,6 +134,7 @@ export async function ofPromise<A, E extends Error>(
  *
  * If the `throwable` throws, an `Err` is returned with the caught error,
  * otherwise the returned value is `Ok`
+ *
  */
 export function ofThrowable<T, E extends Error>(
 	throwable: () => T,

--- a/src/resulta.ts
+++ b/src/resulta.ts
@@ -89,11 +89,11 @@ export function result<A, E extends Error>(value?: A): Result<A, E> {
  *
  */
 export function err<E extends Error>(e: E): Err<E> {
-	let o = Object.create(null) satisfies Err<E>;
-	o.value = null;
-	o.status = ResultStatus.err;
-	o.err = e;
-	return o;
+	return {
+		value: null,
+		status: ResultStatus.err,
+		err: e,
+	} as Err<E>;
 }
 
 /**
@@ -101,12 +101,12 @@ export function err<E extends Error>(e: E): Err<E> {
  * Construct an Ok with a value
  *
  */
-export function ok<A>(t: A): Ok<A> {
-	let o = Object.create(null) satisfies Ok<A>;
-	o.value = t;
-	o.status = ResultStatus.ok;
-	o.err = null;
-	return o;
+export function ok<A>(t: A) {
+	return {
+		value: t,
+		status: ResultStatus.ok,
+		err: null,
+	} as Ok<A>;
 }
 
 /**
@@ -148,7 +148,7 @@ export function ofThrowable<T, E extends Error>(
  * @description
  * Transform the `A` to a new `Result` if `Ok`, otherwise the original `Err`.
  *
- * @alias `bind`
+ * @alias `bind` \ `flatMap`
  */
 export function andThen<A, B, E extends Error>(
 	result: Result<A, E>,


### PR DESCRIPTION
Small change, but in a baseline benchmark of `Result.ok(1)`, resulta was underperforming when compared to its contemporaries. This small change gets perf to a similar level and shaves off a few more bytes with no change in API surface.

why not?